### PR TITLE
chore(project): 项目重命名为Echoes-of-the-Pit

### DIFF
--- a/Echoes-of-the-Pit.csproj
+++ b/Echoes-of-the-Pit.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net9.0</TargetFramework>
         <EnableDynamicLoading>true</EnableDynamicLoading>
-        <RootNamespace>GFrameworkGodotTemplate</RootNamespace>
+        <RootNamespace>EchoesOfThePit</RootNamespace>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
     </PropertyGroup>

--- a/Echoes-of-the-Pit.sln
+++ b/Echoes-of-the-Pit.sln
@@ -1,6 +1,6 @@
 ﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GFramework-Godot-Template", "GFramework-Godot-Template.csproj", "{0181CA84-2114-4E88-981A-CE710E911BF3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Echoes-of-the-Pit", "Echoes-of-the-Pit.csproj", "{0181CA84-2114-4E88-981A-CE710E911BF3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/global/GameEntryPoint.cs
+++ b/global/GameEntryPoint.cs
@@ -1,20 +1,18 @@
+using EchoesOfThePit.scripts.core;
+using EchoesOfThePit.scripts.core.environment;
+using EchoesOfThePit.scripts.core.state.impls;
 using GFramework.Core.Abstractions.architecture;
 using GFramework.Core.Abstractions.logging;
 using GFramework.Core.Abstractions.properties;
 using GFramework.Core.Abstractions.state;
 using GFramework.Core.architecture;
 using GFramework.Core.extensions;
-using GFramework.Game.state;
 using GFramework.Godot.logging;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
-using GFrameworkGodotTemplate.scripts.core;
-using GFrameworkGodotTemplate.scripts.core.environment;
-using GFrameworkGodotTemplate.scripts.core.state;
-using GFrameworkGodotTemplate.scripts.core.state.impls;
 using Godot;
 
-namespace GFrameworkGodotTemplate.global;
+namespace EchoesOfThePit.global;
 
 /// <summary>
 /// 游戏入口点节点类，负责初始化游戏架构和管理全局游戏状态

--- a/global/GlobalInputController.cs
+++ b/global/GlobalInputController.cs
@@ -1,15 +1,15 @@
+using EchoesOfThePit.scripts.command.game;
+using EchoesOfThePit.scripts.command.game.input;
+using EchoesOfThePit.scripts.core.controller;
+using EchoesOfThePit.scripts.core.state.impls;
+using EchoesOfThePit.scripts.events.menu;
 using GFramework.Core.Abstractions.state;
 using GFramework.Core.extensions;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
-using GFrameworkGodotTemplate.scripts.command.game;
-using GFrameworkGodotTemplate.scripts.command.game.input;
-using GFrameworkGodotTemplate.scripts.core.controller;
-using GFrameworkGodotTemplate.scripts.core.state.impls;
-using GFrameworkGodotTemplate.scripts.events.menu;
 using Godot;
 
-namespace GFrameworkGodotTemplate.global;
+namespace EchoesOfThePit.global;
 
 [ContextAware]
 [Log]

--- a/global/UiRoot.cs
+++ b/global/UiRoot.cs
@@ -1,12 +1,12 @@
 using System;
+using EchoesOfThePit.scripts.core.constants;
 using GFramework.Core.extensions;
 using GFramework.Game.Abstractions.ui;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
-using GFrameworkGodotTemplate.scripts.core.constants;
 using Godot;
 
-namespace GFrameworkGodotTemplate.global;
+namespace EchoesOfThePit.global;
 
 /// <summary>
 /// UI画布层根节点，用于管理UI页面的添加和组织

--- a/project.godot
+++ b/project.godot
@@ -10,7 +10,7 @@ config_version=5
 
 [application]
 
-config/name="GFramework-Godot-Template"
+config/name="Echoes-of-the-Pit"
 run/main_scene="uid://6s2urcdmkpbt"
 config/features=PackedStringArray("4.5", "C#", "GL Compatibility")
 config/icon="uid://p5dak2wsc1nk"
@@ -32,7 +32,7 @@ window/size/viewport_height=1080
 
 [dotnet]
 
-project/assembly_name="GFramework-Godot-Template"
+project/assembly_name="Echoes-of-the-Pit"
 
 [file_customization]
 

--- a/scenes/tests/ui/Page1.cs
+++ b/scenes/tests/ui/Page1.cs
@@ -1,14 +1,14 @@
+using EchoesOfThePit.scripts.core.constants;
+using EchoesOfThePit.scripts.core.ui;
 using GFramework.Core.Abstractions.controller;
 using GFramework.Core.extensions;
 using GFramework.Game.Abstractions.ui;
 using GFramework.Godot.ui;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
-using GFrameworkGodotTemplate.scripts.core.constants;
-using GFrameworkGodotTemplate.scripts.core.ui;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scenes.tests.ui;
+namespace EchoesOfThePit.scenes.tests.ui;
 
 [ContextAware]
 [Log]

--- a/scenes/tests/ui/Page2.cs
+++ b/scenes/tests/ui/Page2.cs
@@ -1,14 +1,14 @@
+using EchoesOfThePit.scripts.core.constants;
+using EchoesOfThePit.scripts.core.ui;
 using GFramework.Core.Abstractions.controller;
 using GFramework.Core.extensions;
 using GFramework.Game.Abstractions.ui;
 using GFramework.Godot.ui;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
-using GFrameworkGodotTemplate.scripts.core.constants;
-using GFrameworkGodotTemplate.scripts.core.ui;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scenes.tests.ui;
+namespace EchoesOfThePit.scenes.tests.ui;
 
 [ContextAware]
 [Log]

--- a/scenes/tests/ui/Page3.cs
+++ b/scenes/tests/ui/Page3.cs
@@ -1,14 +1,14 @@
+using EchoesOfThePit.scripts.core.constants;
+using EchoesOfThePit.scripts.core.ui;
 using GFramework.Core.Abstractions.controller;
 using GFramework.Core.extensions;
 using GFramework.Game.Abstractions.ui;
 using GFramework.Godot.ui;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
-using GFrameworkGodotTemplate.scripts.core.constants;
-using GFrameworkGodotTemplate.scripts.core.ui;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scenes.tests.ui;
+namespace EchoesOfThePit.scenes.tests.ui;
 
 [ContextAware]
 [Log]

--- a/scenes/tests/ui/main_menu/TestMainMenu.cs
+++ b/scenes/tests/ui/main_menu/TestMainMenu.cs
@@ -1,14 +1,14 @@
+using EchoesOfThePit.scripts.core.constants;
+using EchoesOfThePit.scripts.core.ui;
 using GFramework.Core.Abstractions.controller;
 using GFramework.Core.extensions;
 using GFramework.Game.Abstractions.ui;
 using GFramework.Godot.ui;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
-using GFrameworkGodotTemplate.scripts.core.constants;
-using GFrameworkGodotTemplate.scripts.core.ui;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scenes.tests.ui.main_menu;
+namespace EchoesOfThePit.scenes.tests.ui.main_menu;
 
 [ContextAware]
 [Log]

--- a/scripts/command/audio/ChangeBgmVolumeCommand.cs
+++ b/scripts/command/audio/ChangeBgmVolumeCommand.cs
@@ -1,10 +1,9 @@
-using GFramework.Core.Abstractions.command;
+using EchoesOfThePit.scripts.command.audio.input;
+using EchoesOfThePit.scripts.setting.interfaces;
 using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFrameworkGodotTemplate.scripts.command.audio.input;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 
-namespace GFrameworkGodotTemplate.scripts.command.audio;
+namespace EchoesOfThePit.scripts.command.audio;
 
 /// <summary>
 /// 更改背景音乐音量命令类，用于处理BGM音量更改操作

--- a/scripts/command/audio/ChangeMasterVolumeCommand.cs
+++ b/scripts/command/audio/ChangeMasterVolumeCommand.cs
@@ -1,10 +1,9 @@
-using GFramework.Core.Abstractions.command;
+using EchoesOfThePit.scripts.command.audio.input;
+using EchoesOfThePit.scripts.setting.interfaces;
 using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFrameworkGodotTemplate.scripts.command.audio.input;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 
-namespace GFrameworkGodotTemplate.scripts.command.audio;
+namespace EchoesOfThePit.scripts.command.audio;
 
 /// <summary>
 /// 更改主音量命令类，用于处理主音量更改操作

--- a/scripts/command/audio/ChangeSfxVolumeCommand.cs
+++ b/scripts/command/audio/ChangeSfxVolumeCommand.cs
@@ -1,10 +1,9 @@
-using GFramework.Core.Abstractions.command;
+using EchoesOfThePit.scripts.command.audio.input;
+using EchoesOfThePit.scripts.setting.interfaces;
 using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFrameworkGodotTemplate.scripts.command.audio.input;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 
-namespace GFrameworkGodotTemplate.scripts.command.audio;
+namespace EchoesOfThePit.scripts.command.audio;
 
 /// <summary>
 /// 更改音效音量命令类，用于处理SFX音量更改操作

--- a/scripts/command/audio/input/ChangeBgmVolumeCommandInput.cs
+++ b/scripts/command/audio/input/ChangeBgmVolumeCommandInput.cs
@@ -1,6 +1,6 @@
 using GFramework.Core.Abstractions.command;
 
-namespace GFrameworkGodotTemplate.scripts.command.audio.input;
+namespace EchoesOfThePit.scripts.command.audio.input;
 
 /// <summary>
 /// 背景音乐音量更改命令输入类，用于传递BGM音量更改所需的参数

--- a/scripts/command/audio/input/ChangeMasterVolumeCommandInput.cs
+++ b/scripts/command/audio/input/ChangeMasterVolumeCommandInput.cs
@@ -1,6 +1,6 @@
 using GFramework.Core.Abstractions.command;
 
-namespace GFrameworkGodotTemplate.scripts.command.audio.input;
+namespace EchoesOfThePit.scripts.command.audio.input;
 
 /// <summary>
 /// 主音量更改命令输入类，用于传递主音量更改所需的参数

--- a/scripts/command/audio/input/ChangeSfxVolumeCommandInput.cs
+++ b/scripts/command/audio/input/ChangeSfxVolumeCommandInput.cs
@@ -1,6 +1,6 @@
 using GFramework.Core.Abstractions.command;
 
-namespace GFrameworkGodotTemplate.scripts.command.audio.input;
+namespace EchoesOfThePit.scripts.command.audio.input;
 
 /// <summary>
 /// 音效音量更改命令输入类，用于传递SFX音量更改所需的参数

--- a/scripts/command/game/PauseGameCommand.cs
+++ b/scripts/command/game/PauseGameCommand.cs
@@ -1,10 +1,10 @@
-﻿using GFramework.Core.Abstractions.state;
+﻿using EchoesOfThePit.scripts.command.game.input;
+using EchoesOfThePit.scripts.core.state.impls;
+using GFramework.Core.Abstractions.state;
 using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFrameworkGodotTemplate.scripts.command.game.input;
-using GFrameworkGodotTemplate.scripts.core.state.impls;
 
-namespace GFrameworkGodotTemplate.scripts.command.game;
+namespace EchoesOfThePit.scripts.command.game;
 
 /// <summary>
 /// 暂停游戏命令类，用于执行暂停游戏的操作

--- a/scripts/command/game/QuitGameCommand.cs
+++ b/scripts/command/game/QuitGameCommand.cs
@@ -1,7 +1,7 @@
-﻿using GFramework.Core.command;
-using GFrameworkGodotTemplate.scripts.command.game.input;
+﻿using EchoesOfThePit.scripts.command.game.input;
+using GFramework.Core.command;
 
-namespace GFrameworkGodotTemplate.scripts.command.game;
+namespace EchoesOfThePit.scripts.command.game;
 
 /// <summary>
 /// 退出游戏命令类，用于处理游戏退出逻辑

--- a/scripts/command/game/ResumeGameCommand.cs
+++ b/scripts/command/game/ResumeGameCommand.cs
@@ -1,11 +1,10 @@
-﻿using GFramework.Core.Abstractions.state;
+﻿using EchoesOfThePit.scripts.command.game.input;
+using EchoesOfThePit.scripts.core.state.impls;
+using GFramework.Core.Abstractions.state;
 using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFramework.Game.state;
-using GFrameworkGodotTemplate.scripts.command.game.input;
-using GFrameworkGodotTemplate.scripts.core.state.impls;
 
-namespace GFrameworkGodotTemplate.scripts.command.game;
+namespace EchoesOfThePit.scripts.command.game;
 
 /// <summary>
 /// 恢复游戏命令类，用于取消游戏暂停状态

--- a/scripts/command/game/input/PauseGameCommandInput.cs
+++ b/scripts/command/game/input/PauseGameCommandInput.cs
@@ -1,8 +1,7 @@
-﻿
-using GFramework.Core.Abstractions.command;
+﻿using GFramework.Core.Abstractions.command;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scripts.command.game.input;
+namespace EchoesOfThePit.scripts.command.game.input;
 
 /// <summary>
 /// 暂停游戏命令输入类，定义执行暂停游戏命令所需的输入参数

--- a/scripts/command/game/input/QuitGameCommandInput.cs
+++ b/scripts/command/game/input/QuitGameCommandInput.cs
@@ -1,8 +1,7 @@
-﻿
-using GFramework.Core.Abstractions.command;
+﻿using GFramework.Core.Abstractions.command;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scripts.command.game.input;
+namespace EchoesOfThePit.scripts.command.game.input;
 
 /// <summary>
 /// 退出游戏命令输入类，封装执行退出游戏命令所需的数据

--- a/scripts/command/game/input/ResumeGameCommandInput.cs
+++ b/scripts/command/game/input/ResumeGameCommandInput.cs
@@ -1,7 +1,7 @@
 ﻿using GFramework.Core.Abstractions.command;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scripts.command.game.input;
+namespace EchoesOfThePit.scripts.command.game.input;
 
 /// <summary>
 /// 恢复游戏命令输入类，封装执行恢复游戏操作所需的数据

--- a/scripts/command/graphics/ChangeResolutionCommand.cs
+++ b/scripts/command/graphics/ChangeResolutionCommand.cs
@@ -1,10 +1,10 @@
 using System.Threading.Tasks;
+using EchoesOfThePit.scripts.command.graphics.input;
+using EchoesOfThePit.scripts.setting.interfaces;
 using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFrameworkGodotTemplate.scripts.command.graphics.input;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 
-namespace GFrameworkGodotTemplate.scripts.command.graphics;
+namespace EchoesOfThePit.scripts.command.graphics;
 
 /// <summary>
 /// 更改分辨率命令类，用于处理分辨率更改操作

--- a/scripts/command/graphics/ToggleFullscreenCommand.cs
+++ b/scripts/command/graphics/ToggleFullscreenCommand.cs
@@ -1,11 +1,10 @@
 using System.Threading.Tasks;
-using GFramework.Core.Abstractions.command;
+using EchoesOfThePit.scripts.command.graphics.input;
+using EchoesOfThePit.scripts.setting.interfaces;
 using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFrameworkGodotTemplate.scripts.command.graphics.input;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 
-namespace GFrameworkGodotTemplate.scripts.command.graphics;
+namespace EchoesOfThePit.scripts.command.graphics;
 
 /// <summary>
 /// 切换全屏模式命令类

--- a/scripts/command/graphics/input/ChangeResolutionCommandInput.cs
+++ b/scripts/command/graphics/input/ChangeResolutionCommandInput.cs
@@ -1,6 +1,6 @@
 using GFramework.Core.Abstractions.command;
 
-namespace GFrameworkGodotTemplate.scripts.command.graphics.input;
+namespace EchoesOfThePit.scripts.command.graphics.input;
 
 /// <summary>
 /// 分辨率更改命令输入类，用于传递分辨率更改所需的参数

--- a/scripts/command/graphics/input/ToggleFullscreenCommandInput.cs
+++ b/scripts/command/graphics/input/ToggleFullscreenCommandInput.cs
@@ -1,6 +1,6 @@
 using GFramework.Core.Abstractions.command;
 
-namespace GFrameworkGodotTemplate.scripts.command.graphics.input;
+namespace EchoesOfThePit.scripts.command.graphics.input;
 
 /// <summary>
 /// 切换全屏命令输入类

--- a/scripts/command/setting/ApplySettingsDataCommand.cs
+++ b/scripts/command/setting/ApplySettingsDataCommand.cs
@@ -1,14 +1,12 @@
 using System.Threading.Tasks;
-using GFramework.Core.Abstractions.command;
+using EchoesOfThePit.scripts.command.setting.input;
+using EchoesOfThePit.scripts.enums.settings;
+using EchoesOfThePit.scripts.events.settings;
+using EchoesOfThePit.scripts.setting.interfaces;
 using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFrameworkGodotTemplate.scripts.command.setting.input;
-using GFrameworkGodotTemplate.scripts.enums.settings;
-using GFrameworkGodotTemplate.scripts.events.settings;
-using GFrameworkGodotTemplate.scripts.setting;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 
-namespace GFrameworkGodotTemplate.scripts.command.setting;
+namespace EchoesOfThePit.scripts.command.setting;
 
 /// <summary>
 /// 应用设置数据命令

--- a/scripts/command/setting/ResetSettingsCommand.cs
+++ b/scripts/command/setting/ResetSettingsCommand.cs
@@ -1,11 +1,11 @@
 ﻿using System.Threading.Tasks;
+using EchoesOfThePit.scripts.enums.settings;
+using EchoesOfThePit.scripts.events.settings;
+using EchoesOfThePit.scripts.setting.interfaces;
 using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFrameworkGodotTemplate.scripts.enums.settings;
-using GFrameworkGodotTemplate.scripts.events.settings;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 
-namespace GFrameworkGodotTemplate.scripts.command.setting;
+namespace EchoesOfThePit.scripts.command.setting;
 
 /// <summary>
 /// 重置设置命令类，用于将音频和图形设置恢复为默认值

--- a/scripts/command/setting/SaveSettingsCommand.cs
+++ b/scripts/command/setting/SaveSettingsCommand.cs
@@ -1,9 +1,9 @@
-﻿using GFramework.Core.command;
+﻿using EchoesOfThePit.scripts.setting;
+using EchoesOfThePit.scripts.setting.interfaces;
+using GFramework.Core.command;
 using GFramework.Core.extensions;
-using GFrameworkGodotTemplate.scripts.setting;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 
-namespace GFrameworkGodotTemplate.scripts.command.setting;
+namespace EchoesOfThePit.scripts.command.setting;
 
 /// <summary>
 /// 保存游戏设置命令类

--- a/scripts/command/setting/input/ApplySettingsDataCommandInput.cs
+++ b/scripts/command/setting/input/ApplySettingsDataCommandInput.cs
@@ -1,7 +1,7 @@
+using EchoesOfThePit.scripts.setting;
 using GFramework.Core.Abstractions.command;
-using GFrameworkGodotTemplate.scripts.setting;
 
-namespace GFrameworkGodotTemplate.scripts.command.setting.input;
+namespace EchoesOfThePit.scripts.command.setting.input;
 
 /// <summary>
 /// 应用设置数据命令输入类

--- a/scripts/constants/GameConstants.cs
+++ b/scripts/constants/GameConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace GFrameworkGodotTemplate.scripts.constants;
+﻿namespace EchoesOfThePit.scripts.constants;
 
 public static class GameConstants
 {

--- a/scripts/core/GameArchitecture.cs
+++ b/scripts/core/GameArchitecture.cs
@@ -1,9 +1,9 @@
+using EchoesOfThePit.scripts.module;
 using GFramework.Core.Abstractions.architecture;
 using GFramework.Core.Abstractions.environment;
 using GFramework.Godot.architecture;
-using GFrameworkGodotTemplate.scripts.module;
 
-namespace GFrameworkGodotTemplate.scripts.core;
+namespace EchoesOfThePit.scripts.core;
 
 /// <summary>
 /// 游戏架构类，负责安装和管理游戏所需的各种模块

--- a/scripts/core/constants/GameConstants.cs
+++ b/scripts/core/constants/GameConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace GFrameworkGodotTemplate.scripts.core.constants;
+﻿namespace EchoesOfThePit.scripts.core.constants;
 
 public static class GameConstants
 {

--- a/scripts/core/constants/UiKeys.cs
+++ b/scripts/core/constants/UiKeys.cs
@@ -1,4 +1,4 @@
-﻿namespace GFrameworkGodotTemplate.scripts.core.constants;
+﻿namespace EchoesOfThePit.scripts.core.constants;
 
 /// <summary>
 /// 定义用户界面相关的键值常量，用于标识不同的UI界面

--- a/scripts/core/constants/UiLayers.cs
+++ b/scripts/core/constants/UiLayers.cs
@@ -1,4 +1,4 @@
-﻿namespace GFrameworkGodotTemplate.scripts.core.constants;
+﻿namespace EchoesOfThePit.scripts.core.constants;
 
 /// <summary>
 /// 定义UI层级常量的静态类，用于管理不同UI元素的渲染层级

--- a/scripts/core/controller/GameInputController.cs
+++ b/scripts/core/controller/GameInputController.cs
@@ -1,7 +1,7 @@
 ﻿using GFramework.Core.Abstractions.controller;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scripts.core.controller;
+namespace EchoesOfThePit.scripts.core.controller;
 
 /// <summary>
 /// 游戏输入控制器抽象基类，继承自Node并实现IController接口

--- a/scripts/core/environment/GameDevEnvironment.cs
+++ b/scripts/core/environment/GameDevEnvironment.cs
@@ -1,7 +1,7 @@
-﻿using GFramework.Core.environment;
-using GFrameworkGodotTemplate.scripts.core.constants;
+﻿using EchoesOfThePit.scripts.core.constants;
+using GFramework.Core.environment;
 
-namespace GFrameworkGodotTemplate.scripts.core.environment;
+namespace EchoesOfThePit.scripts.core.environment;
 
 /// <summary>
 /// 游戏开发环境类，继承自EnvironmentBase

--- a/scripts/core/environment/GameMainEnvironment.cs
+++ b/scripts/core/environment/GameMainEnvironment.cs
@@ -1,7 +1,7 @@
-﻿using GFramework.Core.environment;
-using GFrameworkGodotTemplate.scripts.core.constants;
+﻿using EchoesOfThePit.scripts.core.constants;
+using GFramework.Core.environment;
 
-namespace GFrameworkGodotTemplate.scripts.core.environment;
+namespace EchoesOfThePit.scripts.core.environment;
 
 /// <summary>
 /// 游戏主环境类，继承自EnvironmentBase

--- a/scripts/core/state/impls/GameOverState.cs
+++ b/scripts/core/state/impls/GameOverState.cs
@@ -1,6 +1,6 @@
 using GFramework.Core.state;
 
-namespace GFrameworkGodotTemplate.scripts.core.state.impls;
+namespace EchoesOfThePit.scripts.core.state.impls;
 
 /// <summary>
 /// 游戏结束状态

--- a/scripts/core/state/impls/MainMenuState.cs
+++ b/scripts/core/state/impls/MainMenuState.cs
@@ -1,10 +1,10 @@
+using EchoesOfThePit.scripts.core.constants;
 using GFramework.Core.Abstractions.state;
 using GFramework.Core.extensions;
 using GFramework.Core.state;
 using GFramework.Game.Abstractions.ui;
-using GFrameworkGodotTemplate.scripts.core.constants;
 
-namespace GFrameworkGodotTemplate.scripts.core.state.impls;
+namespace EchoesOfThePit.scripts.core.state.impls;
 
 /// <summary>
 /// 主菜单状态

--- a/scripts/core/state/impls/PausedState.cs
+++ b/scripts/core/state/impls/PausedState.cs
@@ -1,6 +1,6 @@
 using GFramework.Core.state;
 
-namespace GFrameworkGodotTemplate.scripts.core.state.impls;
+namespace EchoesOfThePit.scripts.core.state.impls;
 
 /// <summary>
 /// 暂停状态

--- a/scripts/core/state/impls/PlayingState.cs
+++ b/scripts/core/state/impls/PlayingState.cs
@@ -1,6 +1,6 @@
 using GFramework.Core.state;
 
-namespace GFrameworkGodotTemplate.scripts.core.state.impls;
+namespace EchoesOfThePit.scripts.core.state.impls;
 
 /// <summary>
 /// 游戏进行中状态

--- a/scripts/core/ui/ISimpleUiPage.cs
+++ b/scripts/core/ui/ISimpleUiPage.cs
@@ -1,6 +1,6 @@
 ﻿using GFramework.Game.Abstractions.ui;
 
-namespace GFrameworkGodotTemplate.scripts.core.ui;
+namespace EchoesOfThePit.scripts.core.ui;
 
 /// <summary>
 /// 简单UI页面接口，继承自IUiPage接口

--- a/scripts/core/ui/UiRouter.cs
+++ b/scripts/core/ui/UiRouter.cs
@@ -2,7 +2,7 @@ using GFramework.Game.ui;
 using GFramework.Game.ui.handler;
 using GFramework.SourceGenerators.Abstractions.logging;
 
-namespace GFrameworkGodotTemplate.scripts.core.ui;
+namespace EchoesOfThePit.scripts.core.ui;
 
 /// <summary>
 /// UI路由类，提供页面栈管理功能

--- a/scripts/enums/audio/BgmType.cs
+++ b/scripts/enums/audio/BgmType.cs
@@ -1,5 +1,5 @@
 // 定义背景音乐类型的枚举
-namespace GFrameworkGodotTemplate.scripts.enums.audio;
+namespace EchoesOfThePit.scripts.enums.audio;
 
 /// <summary>
 /// 背景音乐类型枚举，用于标识游戏中不同场景的背景音乐

--- a/scripts/enums/audio/SfxType.cs
+++ b/scripts/enums/audio/SfxType.cs
@@ -1,4 +1,4 @@
-﻿namespace GFrameworkGodotTemplate.scripts.enums.audio;
+﻿namespace EchoesOfThePit.scripts.enums.audio;
 
 /// <summary>
 /// 音效类型枚举，定义了游戏中可用的不同音效类别

--- a/scripts/enums/settings/SettingsChangedReason.cs
+++ b/scripts/enums/settings/SettingsChangedReason.cs
@@ -1,4 +1,4 @@
-﻿namespace GFrameworkGodotTemplate.scripts.enums.settings;
+﻿namespace EchoesOfThePit.scripts.enums.settings;
 
 /// <summary>
 /// 定义设置更改的原因枚举

--- a/scripts/events/audio/BgmChangedEvent.cs
+++ b/scripts/events/audio/BgmChangedEvent.cs
@@ -1,6 +1,6 @@
-﻿using GFrameworkGodotTemplate.scripts.enums.audio;
+﻿using EchoesOfThePit.scripts.enums.audio;
 
-namespace GFrameworkGodotTemplate.scripts.events.audio;
+namespace EchoesOfThePit.scripts.events.audio;
 
 /// <summary>
 /// 背景音乐变更事件类

--- a/scripts/events/audio/PlaySfxEvent.cs
+++ b/scripts/events/audio/PlaySfxEvent.cs
@@ -1,6 +1,6 @@
-﻿using GFrameworkGodotTemplate.scripts.enums.audio;
+﻿using EchoesOfThePit.scripts.enums.audio;
 
-namespace GFrameworkGodotTemplate.scripts.events.audio;
+namespace EchoesOfThePit.scripts.events.audio;
 
 /// <summary>
 /// 音效播放事件类，用于触发特定类型的音效播放

--- a/scripts/events/menu/ClosePauseMenuEvent.cs
+++ b/scripts/events/menu/ClosePauseMenuEvent.cs
@@ -1,4 +1,4 @@
-namespace GFrameworkGodotTemplate.scripts.events.menu;
+namespace EchoesOfThePit.scripts.events.menu;
 
 /// <summary>
 /// 关闭暂停菜单事件

--- a/scripts/events/menu/OpenPauseMenuEvent.cs
+++ b/scripts/events/menu/OpenPauseMenuEvent.cs
@@ -1,4 +1,4 @@
-namespace GFrameworkGodotTemplate.scripts.events.menu;
+namespace EchoesOfThePit.scripts.events.menu;
 
 /// <summary>
 /// 打开暂停菜单事件

--- a/scripts/events/settings/SettingsChangedEvent.cs
+++ b/scripts/events/settings/SettingsChangedEvent.cs
@@ -1,6 +1,6 @@
-﻿using GFrameworkGodotTemplate.scripts.enums.settings;
+﻿using EchoesOfThePit.scripts.enums.settings;
 
-namespace GFrameworkGodotTemplate.scripts.events.settings;
+namespace EchoesOfThePit.scripts.events.settings;
 
 /// <summary>
 /// 表示设置发生更改时触发的事件

--- a/scripts/module/ModelModule.cs
+++ b/scripts/module/ModelModule.cs
@@ -2,7 +2,7 @@
 using GFramework.Game.architecture;
 using GFramework.Game.setting;
 
-namespace GFrameworkGodotTemplate.scripts.module;
+namespace EchoesOfThePit.scripts.module;
 
 /// <summary>
 /// Godot模块实现类，负责安装和注册游戏中的各种模型

--- a/scripts/module/StateModule.cs
+++ b/scripts/module/StateModule.cs
@@ -1,9 +1,9 @@
+using EchoesOfThePit.scripts.core.state.impls;
 using GFramework.Core.Abstractions.architecture;
 using GFramework.Game.architecture;
 using GFramework.Game.state;
-using GFrameworkGodotTemplate.scripts.core.state.impls;
 
-namespace GFrameworkGodotTemplate.scripts.module;
+namespace EchoesOfThePit.scripts.module;
 
 /// <summary>
 /// 状态模块类，负责安装和注册游戏状态系统

--- a/scripts/module/SystemModule.cs
+++ b/scripts/module/SystemModule.cs
@@ -1,9 +1,9 @@
-﻿using GFramework.Core.Abstractions.architecture;
+﻿using EchoesOfThePit.scripts.core.ui;
+using GFramework.Core.Abstractions.architecture;
 using GFramework.Game.architecture;
 using GFramework.Game.setting;
-using GFrameworkGodotTemplate.scripts.core.ui;
 
-namespace GFrameworkGodotTemplate.scripts.module;
+namespace EchoesOfThePit.scripts.module;
 
 /// <summary>
 /// 系统Godot模块类，负责安装和注册游戏所需的各种系统组件

--- a/scripts/module/UtilityModule.cs
+++ b/scripts/module/UtilityModule.cs
@@ -1,13 +1,13 @@
-﻿using GFramework.Core.Abstractions.architecture;
+﻿using EchoesOfThePit.scripts.core.constants;
+using EchoesOfThePit.scripts.setting;
+using GFramework.Core.Abstractions.architecture;
 using GFramework.Game.architecture;
 using GFramework.Game.serializer;
 using GFramework.Godot.storage;
 using GFramework.Godot.ui;
-using GFrameworkGodotTemplate.scripts.core.constants;
-using GFrameworkGodotTemplate.scripts.setting;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scripts.module;
+namespace EchoesOfThePit.scripts.module;
 
 /// <summary>
 /// 工具模块类，负责安装和管理游戏中的实用工具组件

--- a/scripts/setting/AudioSettings.cs
+++ b/scripts/setting/AudioSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace GFrameworkGodotTemplate.scripts.setting;
+﻿namespace EchoesOfThePit.scripts.setting;
 
 /// <summary>
 /// 音频设置类，用于管理游戏中的音频配置

--- a/scripts/setting/GraphicsSettings.cs
+++ b/scripts/setting/GraphicsSettings.cs
@@ -1,4 +1,4 @@
-namespace GFrameworkGodotTemplate.scripts.setting;
+namespace EchoesOfThePit.scripts.setting;
 
 /// <summary>
 /// 图形设置类，用于管理游戏的图形相关配置

--- a/scripts/setting/SettingsData.cs
+++ b/scripts/setting/SettingsData.cs
@@ -1,4 +1,4 @@
-﻿namespace GFrameworkGodotTemplate.scripts.setting;
+﻿namespace EchoesOfThePit.scripts.setting;
 
 /// <summary>
 /// 游戏设置数据类，包含音频和图形设置的配置信息

--- a/scripts/setting/SettingsModel.cs
+++ b/scripts/setting/SettingsModel.cs
@@ -1,7 +1,7 @@
-﻿using GFramework.Core.model;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
+﻿using EchoesOfThePit.scripts.setting.interfaces;
+using GFramework.Core.model;
 
-namespace GFrameworkGodotTemplate.scripts.setting;
+namespace EchoesOfThePit.scripts.setting;
 
 public class SettingsModel: AbstractModel,ISettingsModel
 {

--- a/scripts/setting/SettingsStorageUtility.cs
+++ b/scripts/setting/SettingsStorageUtility.cs
@@ -1,10 +1,10 @@
-﻿using GFramework.Core.Abstractions.storage;
+﻿using EchoesOfThePit.scripts.setting.interfaces;
+using GFramework.Core.Abstractions.storage;
 using GFramework.Core.extensions;
 using GFramework.Core.utility;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scripts.setting;
+namespace EchoesOfThePit.scripts.setting;
 
 /// <summary>
 /// 设置数据存储工具类，负责设置数据的加载和保存

--- a/scripts/setting/SettingsSystem.cs
+++ b/scripts/setting/SettingsSystem.cs
@@ -1,12 +1,12 @@
 using System.Threading.Tasks;
+using EchoesOfThePit.scripts.constants;
+using EchoesOfThePit.scripts.setting.interfaces;
 using GFramework.Core.extensions;
 using GFramework.Core.system;
 using GFramework.SourceGenerators.Abstractions.logging;
-using GFrameworkGodotTemplate.scripts.constants;
-using GFrameworkGodotTemplate.scripts.setting.interfaces;
 using Godot;
 
-namespace GFrameworkGodotTemplate.scripts.setting;
+namespace EchoesOfThePit.scripts.setting;
 
 /// <summary>
 /// 游戏设置系统，负责管理并应用游戏的各项设置（图形、音频等）

--- a/scripts/setting/interfaces/ISettingsModel.cs
+++ b/scripts/setting/interfaces/ISettingsModel.cs
@@ -1,6 +1,6 @@
 ﻿using GFramework.Core.Abstractions.model;
 
-namespace GFrameworkGodotTemplate.scripts.setting.interfaces;
+namespace EchoesOfThePit.scripts.setting.interfaces;
 
 /// <summary>
 /// 定义应用程序设置模型的接口，继承自IModel基础接口

--- a/scripts/setting/interfaces/ISettingsStorageUtility.cs
+++ b/scripts/setting/interfaces/ISettingsStorageUtility.cs
@@ -1,6 +1,6 @@
 ﻿using GFramework.Core.Abstractions.utility;
 
-namespace GFrameworkGodotTemplate.scripts.setting.interfaces;
+namespace EchoesOfThePit.scripts.setting.interfaces;
 
 /// <summary>
 /// 定义设置数据存储工具的接口，提供加载和保存设置数据的功能

--- a/scripts/setting/interfaces/ISettingsSystem.cs
+++ b/scripts/setting/interfaces/ISettingsSystem.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using GFramework.Core.Abstractions.system;
 
-namespace GFrameworkGodotTemplate.scripts.setting.interfaces;
+namespace EchoesOfThePit.scripts.setting.interfaces;
 
 /// <summary>
 /// 定义设置系统的接口，提供应用各种设置的方法


### PR DESCRIPTION
- 将项目名称从GFramework-Godot-Template重命名为Echoes-of-the-Pit
- 更新所有命名空间从GFrameworkGodotTemplate到EchoesOfThePit
- 修改解决方案文件和项目文件中的命名空间引用
- 更新项目配置文件中的程序集名称和应用名称
- 调整所有相关脚本文件的命名空间声明